### PR TITLE
Avoid mutably borrowing the contents of an `Rc.`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1943,7 +1943,7 @@ pub struct Executor {
 
 impl Executor {
     fn ring(&self) -> *mut io_uring {
-        &raw mut *self.p.ioring.borrow_mut()
+        &raw mut *self.p.ioring.as_ptr()
     }
 
     #[must_use]


### PR DESCRIPTION
Fixes #3 by using `as_ptr()` instead of `borrow_mut()`.